### PR TITLE
fixed cursor methods not being passed options 

### DIFF
--- a/lib/kongo-collection.js
+++ b/lib/kongo-collection.js
@@ -77,7 +77,7 @@ cursorMethods.forEach(function(method) {
     var collection = this._collection;
     options = options || {};
     return function(done) {
-      collection[method].call(collection, query)
+      collection[method].call(collection, query, options)
         .limit(options.limit)
         .batchSize(options.batchSize)
         .skip(options.skip)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kongo",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Coroutine based mongo driver for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fixed cursor methods not being passed options which will make impossible for mongo driver to apply projections
